### PR TITLE
First Responder

### DIFF
--- a/HCSStarRatingView/HCSStarRatingView.h
+++ b/HCSStarRatingView/HCSStarRatingView.h
@@ -34,6 +34,8 @@ IB_DESIGNABLE
 @property (nonatomic) IBInspectable BOOL accurateHalfStars;
 @property (nonatomic) IBInspectable BOOL continuous;
 
+@property (nonatomic) BOOL shouldBecomeFirstResponder;
+
 // Optional: if `nil` method will return `NO`.
 @property (nonatomic, copy) HCSStarRatingViewShouldBeginGestureRecognizerBlock shouldBeginGestureRecognizerBlock;
 

--- a/HCSStarRatingView/HCSStarRatingView.m
+++ b/HCSStarRatingView/HCSStarRatingView.m
@@ -302,7 +302,7 @@
 
 - (BOOL)beginTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
     [super beginTrackingWithTouch:touch withEvent:event];
-    if (![self isFirstResponder]) {
+    if (_shouldBecomeFirstResponder && ![self isFirstResponder]) {
         [self becomeFirstResponder];
     }
     [self _handleTouch:touch];
@@ -317,7 +317,7 @@
 
 - (void)endTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
     [super endTrackingWithTouch:touch withEvent:event];
-    if ([self isFirstResponder]) {
+    if (_shouldBecomeFirstResponder && [self isFirstResponder]) {
         [self resignFirstResponder];
     }
     [self _handleTouch:touch];
@@ -328,7 +328,7 @@
 
 - (void)cancelTrackingWithEvent:(UIEvent *)event {
     [super cancelTrackingWithEvent:event];
-    if ([self isFirstResponder]) {
+    if (_shouldBecomeFirstResponder && [self isFirstResponder]) {
         [self resignFirstResponder];
     }
 }
@@ -364,7 +364,7 @@
 #pragma mark - First responder
 
 - (BOOL)canBecomeFirstResponder {
-    return YES;
+    return _shouldBecomeFirstResponder;
 }
 
 #pragma mark - Intrinsic Content Size


### PR DESCRIPTION
I’ve added a property to choose if the control should handle first
responder or not. I’ve done this because I was losing the focus on a
text view while using the control.
I don’t know why the control do this, but instead to remove everything
related to firstResponder, I use a flag.