### PR TITLE
Remove the Info.plist from the podspec

### DIFF
--- a/HCSStarRatingView.podspec
+++ b/HCSStarRatingView.podspec
@@ -10,6 +10,6 @@ Pod::Spec.new do |s|
   s.platform              = :ios
   s.ios.deployment_target = '7.0'
   s.source                = { :git => "https://github.com/hsousa/HCSStarRatingView.git", :tag => "1.4.3" }
-  s.source_files          = "HCSStarRatingView/*"
+  s.source_files          = "HCSStarRatingView/*.{h,m}"
   s.requires_arc          = true
 end


### PR DESCRIPTION
There's not really a good reason the Info.plist needs to be copied over along with the .h and .m files.  Changed the podspec to only copy .h, .m.