### PR TITLE
avoid double init

### DIFF
--- a/HCSStarRatingView/HCSStarRatingView.m
+++ b/HCSStarRatingView/HCSStarRatingView.m
@@ -39,14 +39,6 @@
 
 #pragma mark - Initialization
 
-- (instancetype)init {
-    self = [super init];
-    if (self) {
-        [self _customInit];
-    }
-    return self;
-}
-
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {


### PR DESCRIPTION
Since `init:` method will call `initWithFrame:`, the `_customInit` will be called twice.