### PR TITLE
allow stars to be unselected

### DIFF
--- a/HCSStarRatingView/HCSStarRatingView.h
+++ b/HCSStarRatingView/HCSStarRatingView.h
@@ -30,6 +30,7 @@ IB_DESIGNABLE
 @property (nonatomic) IBInspectable CGFloat minimumValue;
 @property (nonatomic) IBInspectable CGFloat value;
 @property (nonatomic) IBInspectable CGFloat spacing;
+@property (nonatomic) IBInspectable BOOL allowsUnselection;
 @property (nonatomic) IBInspectable BOOL allowsHalfStars;
 @property (nonatomic) IBInspectable BOOL accurateHalfStars;
 @property (nonatomic) IBInspectable BOOL continuous;

--- a/HCSStarRatingView/HCSStarRatingView.m
+++ b/HCSStarRatingView/HCSStarRatingView.m
@@ -30,6 +30,7 @@
     CGFloat _minimumValue;
     NSUInteger _maximumValue;
     CGFloat _value;
+    CGFloat _oldValue;
 }
 
 @dynamic minimumValue;
@@ -373,6 +374,20 @@
         }
     } else {
         value = ceilf(value);
+    }
+
+    switch (touch.phase) {
+        case UITouchPhaseBegan:
+            _oldValue = _value;
+            break;
+        case UITouchPhaseCancelled:
+        case UITouchPhaseEnded:
+            if (self.allowsUnselection && value == _oldValue) {
+                value = 0;
+            }
+            break;
+        default:
+            break;
     }
     [self setValue:value sendValueChangedAction:_continuous];
 }


### PR DESCRIPTION
This is not meant to be a final PR, but a point of discussion. This code works and allows stars to be unselected. Maybe the only point of contention is the setting of '0' to be the 'unselected' value. I figure we do this since even the 'minimumValue' takes a max of 0 and _minimumValue. Let me know your thoughts. Thanks for the library!
