### PR TITLE
Fix intrinsicContentSize dependence on custom images.

### DIFF
--- a/HCSStarRatingView/HCSStarRatingView.m
+++ b/HCSStarRatingView/HCSStarRatingView.m
@@ -386,7 +386,8 @@
 #pragma mark - Intrinsic Content Size
 
 - (CGSize)intrinsicContentSize {
-    CGFloat height = 44.f;
+    UIImage *emptyStarImage = self.emptyStarImage;
+    CGFloat height = emptyStarImage ? emptyStarImage.size.height : 44.f;
     return CGSizeMake(_maximumValue * height + (_maximumValue-1) * _spacing, height);
 }
 

--- a/HCSStarRatingView/HCSStarRatingView.m
+++ b/HCSStarRatingView/HCSStarRatingView.m
@@ -267,6 +267,7 @@
     CGFloat availableWidth = rect.size.width - (_spacing * (_maximumValue - 1)) - 2;
     CGFloat cellWidth = (availableWidth / _maximumValue);
     CGFloat starSide = (cellWidth <= rect.size.height) ? cellWidth : rect.size.height;
+    if (self.emptyStarImage) starSide = self.emptyStarImage.size.height;
     for (int idx = 0; idx < _maximumValue; idx++) {
         CGPoint center = CGPointMake(cellWidth*idx + cellWidth/2 + _spacing*idx + 1, rect.size.height/2);
         CGRect frame = CGRectMake(center.x - starSide/2, center.y - starSide/2, starSide, starSide);
@@ -386,8 +387,7 @@
 #pragma mark - Intrinsic Content Size
 
 - (CGSize)intrinsicContentSize {
-    UIImage *emptyStarImage = self.emptyStarImage;
-    CGFloat height = emptyStarImage ? emptyStarImage.size.height : 44.f;
+    CGFloat height = MAX(44.f, self.emptyStarImage.size.height);
     return CGSizeMake(_maximumValue * height + (_maximumValue-1) * _spacing, height);
 }
 


### PR DESCRIPTION
Before the fix custom images were scaled to match fixed 44 point height.
Now `intrinsicContentSize` depends on size of custom image to prevent image scaling.

Hi. I hope I don't miss anything, but it works for me.