### PR TITLE
Added star empty state color, border color and border width

### DIFF
--- a/HCSStarRatingView/HCSStarRatingView.h
+++ b/HCSStarRatingView/HCSStarRatingView.h
@@ -39,6 +39,12 @@ IB_DESIGNABLE
 // Optional: if `nil` method will return `NO`.
 @property (nonatomic, copy) HCSStarRatingViewShouldBeginGestureRecognizerBlock shouldBeginGestureRecognizerBlock;
 
+@property (nonatomic, strong) IBInspectable UIColor *starBorderColor;
+@property (nonatomic) IBInspectable CGFloat starBorderWidth;
+
+@property (nonatomic, strong) IBInspectable UIColor *emptyStarColor;
+@property (nonatomic, strong) IBInspectable UIColor *filledStarColor;
+
 @property (nonatomic, strong) IBInspectable UIImage *emptyStarImage;
 @property (nonatomic, strong) IBInspectable UIImage *halfStarImage;
 @property (nonatomic, strong) IBInspectable UIImage *filledStarImage;

--- a/HCSStarRatingView/HCSStarRatingView.h
+++ b/HCSStarRatingView/HCSStarRatingView.h
@@ -43,7 +43,6 @@ IB_DESIGNABLE
 @property (nonatomic) IBInspectable CGFloat starBorderWidth;
 
 @property (nonatomic, strong) IBInspectable UIColor *emptyStarColor;
-@property (nonatomic, strong) IBInspectable UIColor *filledStarColor;
 
 @property (nonatomic, strong) IBInspectable UIImage *emptyStarImage;
 @property (nonatomic, strong) IBInspectable UIImage *halfStarImage;

--- a/HCSStarRatingView/HCSStarRatingView.m
+++ b/HCSStarRatingView/HCSStarRatingView.m
@@ -30,12 +30,14 @@
     CGFloat _minimumValue;
     NSUInteger _maximumValue;
     CGFloat _value;
+    UIColor *_starBorderColor;
 }
 
 @dynamic minimumValue;
 @dynamic maximumValue;
 @dynamic value;
 @dynamic shouldUseImages;
+@dynamic starBorderColor;
 
 #pragma mark - Initialization
 
@@ -63,10 +65,7 @@
     _spacing = 5.f;
     _continuous = YES;
     _starBorderWidth = 1.0f;
-    _starBorderColor = self.tintColor;
     _emptyStarColor = [UIColor clearColor];
-    _filledStarColor = self.tintColor;
-    
     
     [self _updateAppearanceForState:self.enabled];
 }
@@ -167,34 +166,30 @@
     }
 }
 
-
-- (void)setFilledStarColor:(UIColor *)filledStarColor {
-    if(_filledStarColor != filledStarColor) {
-        _filledStarColor = filledStarColor;
-        [self setNeedsDisplay];
-    }
-}
-
 - (void)setEmptyStarColor:(UIColor *)emptyStarColor {
-    if(_emptyStarColor != emptyStarColor) {
+    if (_emptyStarColor != emptyStarColor) {
         _emptyStarColor = emptyStarColor;
         [self setNeedsDisplay];
     }
 }
 
-- (void)setStarBorderColor:(UIColor *)startBorderColor {
-    if(_starBorderColor != startBorderColor) {
-        _starBorderColor = startBorderColor;
+- (void)setStarBorderColor:(UIColor *)starBorderColor {
+    if (_starBorderColor != starBorderColor) {
+        _starBorderColor = starBorderColor;
         [self setNeedsDisplay];
     }
 }
 
-- (void)setStarBorderWidth:(CGFloat)startBorderWidth {
-    if(startBorderWidth < 0){
-        startBorderWidth = 0;
+- (UIColor *)starBorderColor {
+    if (_starBorderColor == nil) {
+        return self.tintColor;
+    } else {
+        return _starBorderColor;
     }
-    
-    _starBorderWidth = startBorderWidth;
+}
+
+- (void)setStarBorderWidth:(CGFloat)starBorderWidth {
+    _starBorderWidth = MAX(0, starBorderWidth);
     [self setNeedsDisplay];
 }
 
@@ -288,12 +283,12 @@
     
     CGContextSaveGState(UIGraphicsGetCurrentContext()); {
         [clipPath addClip];
-        [_filledStarColor setFill];
+        [tintColor setFill];
         [starShapePath fill];
     }
     CGContextRestoreGState(UIGraphicsGetCurrentContext());
     
-    [_starBorderColor setStroke];
+    [self.starBorderColor setStroke];
     starShapePath.lineWidth = _starBorderWidth;
     [starShapePath stroke];
 }
@@ -308,7 +303,7 @@
     CGFloat availableWidth = rect.size.width - (_spacing * (_maximumValue - 1)) - 2;
     CGFloat cellWidth = (availableWidth / _maximumValue);
     CGFloat starSide = (cellWidth <= rect.size.height) ? cellWidth : rect.size.height;
-    starSide = (self.shouldUseImages)? starSide : (starSide - _starBorderWidth);
+    starSide = (self.shouldUseImages) ? starSide : (starSide - _starBorderWidth);
     
     for (int idx = 0; idx < _maximumValue; idx++) {
         CGPoint center = CGPointMake(cellWidth*idx + cellWidth/2 + _spacing*idx + 1, rect.size.height/2);

--- a/HCSStarRatingView/HCSStarRatingView.m
+++ b/HCSStarRatingView/HCSStarRatingView.m
@@ -62,6 +62,12 @@
     _value = 0;
     _spacing = 5.f;
     _continuous = YES;
+    _starBorderWidth = 1.0f;
+    _starBorderColor = self.tintColor;
+    _emptyStarColor = [UIColor clearColor];
+    _filledStarColor = self.tintColor;
+    
+    
     [self _updateAppearanceForState:self.enabled];
 }
 
@@ -161,6 +167,38 @@
     }
 }
 
+
+- (void)setFilledStarColor:(UIColor *)filledStarColor {
+    if(_filledStarColor != filledStarColor) {
+        _filledStarColor = filledStarColor;
+        [self setNeedsDisplay];
+    }
+}
+
+- (void)setEmptyStarColor:(UIColor *)emptyStarColor {
+    if(_emptyStarColor != emptyStarColor) {
+        _emptyStarColor = emptyStarColor;
+        [self setNeedsDisplay];
+    }
+}
+
+- (void)setStarBorderColor:(UIColor *)startBorderColor {
+    if(_starBorderColor != startBorderColor) {
+        _starBorderColor = startBorderColor;
+        [self setNeedsDisplay];
+    }
+}
+
+- (void)setStarBorderWidth:(CGFloat)startBorderWidth {
+    if(startBorderWidth < 0){
+        startBorderWidth = 0;
+    }
+    
+    _starBorderWidth = startBorderWidth;
+    [self setNeedsDisplay];
+}
+
+
 - (BOOL)shouldUseImages {
     return (self.emptyStarImage!=nil && self.filledStarImage!=nil);
 }
@@ -245,15 +283,18 @@
     [clipPath appendPath:[UIBezierPath bezierPathWithRect:rightRectOfStar]];
     clipPath.usesEvenOddFillRule = YES;
     
+    [_emptyStarColor setFill];
+    [starShapePath fill];
+    
     CGContextSaveGState(UIGraphicsGetCurrentContext()); {
         [clipPath addClip];
-        [tintColor setFill];
+        [_filledStarColor setFill];
         [starShapePath fill];
     }
     CGContextRestoreGState(UIGraphicsGetCurrentContext());
     
-    [tintColor setStroke];
-    starShapePath.lineWidth = 1;
+    [_starBorderColor setStroke];
+    starShapePath.lineWidth = _starBorderWidth;
     [starShapePath stroke];
 }
 
@@ -267,6 +308,8 @@
     CGFloat availableWidth = rect.size.width - (_spacing * (_maximumValue - 1)) - 2;
     CGFloat cellWidth = (availableWidth / _maximumValue);
     CGFloat starSide = (cellWidth <= rect.size.height) ? cellWidth : rect.size.height;
+    starSide = (self.shouldUseImages)? starSide : (starSide - _starBorderWidth);
+    
     for (int idx = 0; idx < _maximumValue; idx++) {
         CGPoint center = CGPointMake(cellWidth*idx + cellWidth/2 + _spacing*idx + 1, rect.size.height/2);
         CGRect frame = CGRectMake(center.x - starSide/2, center.y - starSide/2, starSide, starSide);


### PR DESCRIPTION
This will allow to change the empty state color, so we will be able use separate colors for star fill state and empty state. In addition star border color and width properties are also configurable through IBInspectable. This will cover most of the UI variations if you want to stick with stars for rating. 

![screen shot 2016-11-04 at 4 01 28 pm](https://cloud.githubusercontent.com/assets/5644639/20005917/d461bb40-a2b6-11e6-9c15-a3296dd0dce2.png)

![screen shot 2016-11-04 at 4 01 51 pm](https://cloud.githubusercontent.com/assets/5644639/20005934/e9fcba4a-a2b6-11e6-886b-15ccb6c4d831.png)
