### PR TITLE
Allow change in star shape programmatically

### DIFF
--- a/HCSStarRatingView/HCSStarRatingView.h
+++ b/HCSStarRatingView/HCSStarRatingView.h
@@ -47,5 +47,8 @@ IB_DESIGNABLE
 @property (nonatomic, strong) IBInspectable UIImage *emptyStarImage;
 @property (nonatomic, strong) IBInspectable UIImage *halfStarImage;
 @property (nonatomic, strong) IBInspectable UIImage *filledStarImage;
+
+- (void)_drawAccurateHalfStarShapeWithFrame:(CGRect)frame tintColor:(UIColor *)tintColor progress:(CGFloat)progress;
+
 @end
 


### PR DESCRIPTION
Allows change in star shape programmatically by overriding the - (void)_drawAccurateHalfStarShapeWithFrame:(CGRect)frame tintColor:(UIColor *)tintColor progress:(CGFloat)progress {
 method